### PR TITLE
Noves fòrmules de preu indexat pels subsistemes balear i canari

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,86 @@ Where:
 * **pmd**: prmdiari
 * **perdues**: perdxxxxx
 
+## PHF BALEARES formula
+
+ `PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K] + PA + CA`
+
+Where:
+
+* **IMU**: Impost Municipal [%]
+* **SPHDEM**:  Precio Medio de Demanda en los sistemas no peninsulares [€/MWh]
+* **PC_REE**: Pagos por capacidad según REE [€/kWh]
+* **SI**: Precio Servicio Interrumpibilidad [€/MWh]
+* **POS**: Preu Operació Sistema [€/MWh]
+* **Perdidas**: Perdidas por tarifa [%]
+* **FNEE**: Pagos al fondo de eficiencia según consumo computado [€/MWh]
+* **K**: Coeficiente de comercializadora [€/kWh]
+* **PA**: Peajes de acceso según BOE [€/kWh]
+* **CA**: Cargos según BOE [€/kWh]
+
+### Hourly Coeficients
+
+* **SPHDEM**: liquicomun -> sphdem
+* **Perdidas**: liquicomun -> Sperdxxxxx. xxxxx diferent by tariff
+
+### Pricelist coeficients by period
+
+* **PA**: Peajes (BOE). ERP Module `giscedata_tarifas_peajes_yyyymmdd`
+* **CA**: Cargos (BOE). ERP Module `giscedata_tarifas_cargos_yyyymmdd`
+
+### Pricelist coeficients
+
+* **IMU**: Impuesto Municipal. Fixed value by pricelist and version.
+* **FNEE**: Pagos Fondo Eficiencia. Fixed value by pricelist and version
+* **K**: Margen comercializadora. Fixed value by pricelist and version OR by contract (`coeficient_k` field)
+
+### audit files
+
+* **phf**: Precio Horario Final (incluye consumo)
+* **curve**: Curva
+* **pmd**: sphdem
+* **perdues**: perdxxxxx
+
+## PHF BALEARES formula
+
+ `PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K] + PA + CA`
+
+Where:
+
+* **IMU**: Impost Municipal [%]
+* **SPHDEM**:  Precio Medio de Demanda en los sistemas no peninsulares [€/MWh]
+* **PC_REE**: Pagos por capacidad según REE [€/kWh]
+* **SI**: Precio Servicio Interrumpibilidad [€/MWh]
+* **POS**: Preu Operació Sistema [€/MWh]
+* **Perdidas**: Perdidas por tarifa [%]
+* **FNEE**: Pagos al fondo de eficiencia según consumo computado [€/MWh]
+* **K**: Coeficiente de comercializadora [€/kWh]
+* **PA**: Peajes de acceso según BOE [€/kWh]
+* **CA**: Cargos según BOE [€/kWh]
+
+### Hourly Coeficients
+
+* **SPHDEM**: liquicomun -> sphdem
+* **Perdidas**: liquicomun -> Sperdxxxxx. xxxxx diferent by tariff
+
+### Pricelist coeficients by period
+
+* **PA**: Peajes (BOE). ERP Module `giscedata_tarifas_peajes_yyyymmdd`
+* **CA**: Cargos (BOE). ERP Module `giscedata_tarifas_cargos_yyyymmdd`
+
+### Pricelist coeficients
+
+* **IMU**: Impuesto Municipal. Fixed value by pricelist and version.
+* **FNEE**: Pagos Fondo Eficiencia. Fixed value by pricelist and version
+* **K**: Margen comercializadora. Fixed value by pricelist and version OR by contract (`coeficient_k` field)
+
+### audit files
+
+* **phf**: Precio Horario Final (incluye consumo)
+* **curve**: Curva
+* **pmd**: sphdem
+* **perdues**: perdxxxxx
+
 ## PHF Generació
 
  `PHF = [PMD]`

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Where:
 
 ## PHF BALEARES formula
 
- `PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K] + PA + CA`
+ `PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K + D] + PA + CA`
 
 Where:
 
@@ -102,10 +102,11 @@ Where:
 * **SPHDEM**:  Precio Medio de Demanda en los sistemas no peninsulares [€/MWh]
 * **PC_REE**: Pagos por capacidad según REE [€/kWh]
 * **SI**: Precio Servicio Interrumpibilidad [€/MWh]
-* **POS**: Preu Operació Sistema [€/MWh]
+* **POS**: Preu Operació Sistema (REE) [€/MWh]
 * **Perdidas**: Perdidas por tarifa [%]
 * **FNEE**: Pagos al fondo de eficiencia según consumo computado [€/MWh]
 * **K**: Coeficiente de comercializadora [€/kWh]
+* **D**: Coeficiente de desvíos [€/kWh]
 * **PA**: Peajes de acceso según BOE [€/kWh]
 * **CA**: Cargos según BOE [€/kWh]
 
@@ -123,7 +124,9 @@ Where:
 
 * **IMU**: Impuesto Municipal. Fixed value by pricelist and version.
 * **FNEE**: Pagos Fondo Eficiencia. Fixed value by pricelist and version
+* **POS**: Precio retribución a Operador del Sistema (REE). Fixed value by pricelist and version
 * **K**: Margen comercializadora. Fixed value by pricelist and version OR by contract (`coeficient_k` field)
+* **D**: Margen desvíos. Fixed value by pricelist and version OR by contract (`coeficient_d` field)
 
 ### audit files
 
@@ -134,7 +137,7 @@ Where:
 
 ## PHF BALEARES formula
 
- `PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K] + PA + CA`
+ `PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K + D] + PA + CA`
 
 Where:
 
@@ -146,6 +149,7 @@ Where:
 * **Perdidas**: Perdidas por tarifa [%]
 * **FNEE**: Pagos al fondo de eficiencia según consumo computado [€/MWh]
 * **K**: Coeficiente de comercializadora [€/kWh]
+* **D**: Coeficiente de desvíos [€/kWh]
 * **PA**: Peajes de acceso según BOE [€/kWh]
 * **CA**: Cargos según BOE [€/kWh]
 
@@ -163,7 +167,9 @@ Where:
 
 * **IMU**: Impuesto Municipal. Fixed value by pricelist and version.
 * **FNEE**: Pagos Fondo Eficiencia. Fixed value by pricelist and version
+* **POS**: Precio retribución a Operador del Sistema (REE). Fixed value by pricelist and version
 * **K**: Margen comercializadora. Fixed value by pricelist and version OR by contract (`coeficient_k` field)
+* **D**: Margen desvíos. Fixed value by pricelist and version OR by contract (`coeficient_d` field)
 
 ### audit files
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-esios>=0.11.0
-libFacturacioATR>=5.9.0
+esios>=0.12.5
+libFacturacioATR>=8.1.0

--- a/tarifes.py
+++ b/tarifes.py
@@ -23,6 +23,10 @@ class TarifaPoolSOM(TarifaPool):
             res['pmd'] = 'prmdiari'
             res['pc3_ree'] = 'pc3_boe'
             res['pos'] = 'sobrecostes_ree'
+        if self.phf_function in ('phf_calc_baleares', 'phf_calc_canaries'):
+            # only if 'phf_calc_peninsula' formula is used
+            res['pmd'] = 'sphdem'
+            res['pc3_ree'] = 'pc3_ree'
 
         return res
 
@@ -215,6 +219,140 @@ class TarifaPoolSOM(TarifaPool):
 
         return component
 
+    def phf_calc_balears(self, curve, start_date):
+        """
+        Calcs component PHF as:
+        PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K] + PA + CA
+        :param curve: Component curve
+        :param start_date: component start date
+        :return: returns a component
+        """
+        num_days = calendar.monthrange(start_date.year, start_date.month)[1]
+        end_date = datetime(
+            start_date.year, start_date.month, num_days
+        ).date()
+
+        esios_token = self.conf['esios_token']
+        holidays = self.conf['holidays']
+
+        # REE
+        # Precio horario demanda aplicable sistema no peninsular
+        postfix = ('%s_%s' % (start_date.strftime("%Y%m%d"), end_date.strftime("%Y%m%d")))
+        if self.geom_zone is None or self.geom_zone == '1':
+            raise ValueError('Geom Zone must be a non-peninsular subsystem')
+        filename = 'SphdemDD_{}'.format(SUBSYSTEMS_SPHDEM[self.geom_zone])
+        classname = globals()[filename]
+        sphdem = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
+        # Pagos por capacidad
+        filename = 'Sprpcap{}_{}'.format(self.code, SUBSYSTEMS_SPHDEM[self.geom_zone])
+        pc3_ree = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
+        # Servicio de Interrumpibilidad
+        si = SIFree('C2_sifree_%(postfix)s' % locals(), esios_token)  # [€/MWh]
+        # Coeficientes de pérdidas
+        self.get_perdclass()
+        fname = self.perdclass.name
+        perdues = self.perdclass('C2_%(fname)s_%(postfix)s' % locals(), esios_token)  # [%]
+
+        # Pricelist and contract
+        # Fondo de Eficiencia
+        fe = self.get_coeficient_component(start_date, 'fe')  # [€/MWh]
+        # Contract specific coeficients
+        k = self.get_coeficient_component(start_date, 'k')  # [€/kWh]
+        # Municipal fee
+        imu = self.get_coeficient_component(start_date, 'imu')  # [%]
+
+        # peajes y cargos
+        pa = self.get_peaje_component(start_date, holidays)  # [€/kWh]
+
+        A = ((sphdem + pc3_ree + si) * 0.001)
+        B = (1 + (perdues * 0.01))
+        C = A * B
+        D = (fe * 0.001) + k
+        E = C + D
+        F = E * (1 + (imu * 0.01))
+        G = F + pa
+        H = curve * 0.001
+        component = H * G
+
+        audit_keys = self.get_available_audit_coefs()
+        for key in self.conf.get('audit', []):
+            if key not in self.audit_data.keys():
+                self.audit_data[key] = []
+            var_name = audit_keys[key]
+            com = locals()[var_name]
+            self.audit_data[key].extend(
+                com.get_audit_data(start=start_date.day)
+            )
+
+        return component
+
+    def phf_calc_canaries(self, curve, start_date):
+        """
+        Calcs component PHF as:
+        PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K] + PA + CA
+        :param curve: Component curve
+        :param start_date: component start date
+        :return: returns a component
+        """
+        num_days = calendar.monthrange(start_date.year, start_date.month)[1]
+        end_date = datetime(
+            start_date.year, start_date.month, num_days
+        ).date()
+
+        esios_token = self.conf['esios_token']
+        holidays = self.conf['holidays']
+
+        # REE
+        # Precio horario demanda aplicable sistema no peninsular
+        postfix = ('%s_%s' % (start_date.strftime("%Y%m%d"), end_date.strftime("%Y%m%d")))
+        if self.geom_zone is None or self.geom_zone == '1':
+            raise ValueError('Geom Zone must be a non-peninsular subsystem')
+        filename = 'SphdemDD_{}'.format(SUBSYSTEMS_SPHDEM[self.geom_zone])
+        classname = globals()[filename]
+        sphdem = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
+        # Pagos por capacidad
+        filename = 'Sprpcap{}_{}'.format(self.code, SUBSYSTEMS_SPHDEM[self.geom_zone])
+        pc3_ree = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
+        # Servicio de Interrumpibilidad
+        si = SIFree('C2_sifree_%(postfix)s' % locals(), esios_token)  # [€/MWh]
+        # Coeficientes de pérdidas
+        self.get_perdclass()
+        fname = self.perdclass.name
+        perdues = self.perdclass('C2_%(fname)s_%(postfix)s' % locals(), esios_token)  # [%]
+
+        # Pricelist and contract
+        # Fondo de Eficiencia
+        fe = self.get_coeficient_component(start_date, 'fe')  # [€/MWh]
+        # Contract specific coeficients
+        k = self.get_coeficient_component(start_date, 'k')  # [€/kWh]
+        # Municipal fee
+        imu = self.get_coeficient_component(start_date, 'imu')  # [%]
+
+        # peajes y cargos
+        pa = self.get_peaje_component(start_date, holidays)  # [€/kWh]
+
+        A = ((sphdem + pc3_ree + si) * 0.001)
+        B = (1 + (perdues * 0.01))
+        C = A * B
+        D = (fe * 0.001) + k
+        E = C + D
+        F = E * (1 + (imu * 0.01))
+        G = F + pa
+        H = curve * 0.001
+        component = H * G
+
+        audit_keys = self.get_available_audit_coefs()
+        for key in self.conf.get('audit', []):
+            if key not in self.audit_data.keys():
+                self.audit_data[key] = []
+            var_name = audit_keys[key]
+            com = locals()[var_name]
+            self.audit_data[key].extend(
+                com.get_audit_data(start=start_date.day)
+            )
+
+        return component
+
     def get_available_indexed_formulas(self):
         """
         Gets available formulas for indexed invoicing
@@ -223,7 +361,9 @@ class TarifaPoolSOM(TarifaPool):
         """
         return {
             u'Indexada': 'phf_calc',
-            u'Indexada Península': 'phf_calc_peninsula'
+            u'Indexada Península': 'phf_calc_peninsula',
+            u'Indexada Balears': 'phf_calc_balears',
+            u'Indexada Canàries': 'phf_calc_canaries',
         }
 
 

--- a/tarifes.py
+++ b/tarifes.py
@@ -255,20 +255,23 @@ class TarifaPoolSOM(TarifaPool):
         perdues = self.perdclass('C2_%(fname)s_%(postfix)s' % locals(), esios_token)  # [%]
 
         # Pricelist and contract
+        # Coste remuneración REE
+        ree = self.get_coeficient_component(start_date, 'omie')  # [€/MWh]
         # Fondo de Eficiencia
         fe = self.get_coeficient_component(start_date, 'fe')  # [€/MWh]
         # Contract specific coeficients
         k = self.get_coeficient_component(start_date, 'k')  # [€/kWh]
+        d = self.get_coeficient_component(start_date, 'd')  # [€/kWh]
         # Municipal fee
         imu = self.get_coeficient_component(start_date, 'imu')  # [%]
 
         # peajes y cargos
         pa = self.get_peaje_component(start_date, holidays)  # [€/kWh]
 
-        A = ((sphdem + pc3_ree + si) * 0.001)
+        A = ((sphdem + pc3_ree + si + ree) * 0.001)
         B = (1 + (perdues * 0.01))
         C = A * B
-        D = (fe * 0.001) + k
+        D = (fe * 0.001) + k + d
         E = C + D
         F = E * (1 + (imu * 0.01))
         G = F + pa
@@ -323,20 +326,23 @@ class TarifaPoolSOM(TarifaPool):
         perdues = self.perdclass('C2_%(fname)s_%(postfix)s' % locals(), esios_token)  # [%]
 
         # Pricelist and contract
+        # Coste remuneración REE
+        ree = self.get_coeficient_component(start_date, 'omie')  # [€/MWh]
         # Fondo de Eficiencia
         fe = self.get_coeficient_component(start_date, 'fe')  # [€/MWh]
         # Contract specific coeficients
         k = self.get_coeficient_component(start_date, 'k')  # [€/kWh]
+        d = self.get_coeficient_component(start_date, 'd')  # [€/kWh]
         # Municipal fee
         imu = self.get_coeficient_component(start_date, 'imu')  # [%]
 
         # peajes y cargos
         pa = self.get_peaje_component(start_date, holidays)  # [€/kWh]
 
-        A = ((sphdem + pc3_ree + si) * 0.001)
+        A = ((sphdem + pc3_ree + si + ree) * 0.001)
         B = (1 + (perdues * 0.01))
         C = A * B
-        D = (fe * 0.001) + k
+        D = (fe * 0.001) + k + d
         E = C + D
         F = E * (1 + (imu * 0.01))
         G = F + pa

--- a/tarifes.py
+++ b/tarifes.py
@@ -23,7 +23,7 @@ class TarifaPoolSOM(TarifaPool):
             res['pmd'] = 'prmdiari'
             res['pc3_ree'] = 'pc3_boe'
             res['pos'] = 'sobrecostes_ree'
-        if self.phf_function in ('phf_calc_baleares', 'phf_calc_canaries'):
+        if self.phf_function in ('phf_calc_balears', 'phf_calc_canaries'):
             # only if 'phf_calc_peninsula' formula is used
             res['pmd'] = 'sphdem'
             res['pc3_ree'] = 'pc3_ree'
@@ -238,13 +238,14 @@ class TarifaPoolSOM(TarifaPool):
         # REE
         # Precio horario demanda aplicable sistema no peninsular
         postfix = ('%s_%s' % (start_date.strftime("%Y%m%d"), end_date.strftime("%Y%m%d")))
-        if self.geom_zone is None or self.geom_zone == '1':
-            raise ValueError('Geom Zone must be a non-peninsular subsystem')
+        if self.geom_zone is None or self.geom_zone != '2':
+            raise ValueError('Geom Zone must be Balear subsystem')
         filename = 'SphdemDD_{}'.format(SUBSYSTEMS_SPHDEM[self.geom_zone])
         classname = globals()[filename]
         sphdem = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
         # Pagos por capacidad
-        filename = 'Sprpcap{}_{}'.format(self.code, SUBSYSTEMS_SPHDEM[self.geom_zone])
+        filename = 'Sprpcap{}_{}'.format(self.code.replace('.', ''), SUBSYSTEMS_SPHDEM[self.geom_zone])
+        classname = globals()[filename]
         pc3_ree = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
         # Servicio de Interrumpibilidad
         si = SIFree('C2_sifree_%(postfix)s' % locals(), esios_token)  # [€/MWh]
@@ -305,13 +306,14 @@ class TarifaPoolSOM(TarifaPool):
         # REE
         # Precio horario demanda aplicable sistema no peninsular
         postfix = ('%s_%s' % (start_date.strftime("%Y%m%d"), end_date.strftime("%Y%m%d")))
-        if self.geom_zone is None or self.geom_zone == '1':
-            raise ValueError('Geom Zone must be a non-peninsular subsystem')
+        if self.geom_zone is None or self.geom_zone != '3':
+            raise ValueError('Geom Zone must be Canarian subsystem')
         filename = 'SphdemDD_{}'.format(SUBSYSTEMS_SPHDEM[self.geom_zone])
         classname = globals()[filename]
         sphdem = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
         # Pagos por capacidad
-        filename = 'Sprpcap{}_{}'.format(self.code, SUBSYSTEMS_SPHDEM[self.geom_zone])
+        filename = 'Sprpcap{}_{}'.format(self.code.replace('.', ''), SUBSYSTEMS_SPHDEM[self.geom_zone])
+        classname = globals()[filename]
         pc3_ree = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
         # Servicio de Interrumpibilidad
         si = SIFree('C2_sifree_%(postfix)s' % locals(), esios_token)  # [€/MWh]

--- a/tests/indexada_tests.py
+++ b/tests/indexada_tests.py
@@ -47,7 +47,7 @@ class IndexadaSOMTest(testing.OOTestCase):
 
         wz_id_mod = wz_crear_mc_obj.create(cursor, uid, params, ctx)
         wiz_mod = wz_crear_mc_obj.browse(cursor, uid, wz_id_mod, ctx)
-        res = wz_crear_mc_obj.onchange_duracio(
+        wz_crear_mc_obj.onchange_duracio(
             cursor, uid, [wz_id_mod], wiz_mod.data_inici, wiz_mod.duracio,
             ctx
         )
@@ -424,33 +424,32 @@ class IndexadaSOMTest(testing.OOTestCase):
                 os.remove('/tmp/curve_data.csv')
 
     def test_phf_balears(self):
-        ESIOS_TOKEN = tools.config['esios_token']
-        token = ESIOS_TOKEN
-
         facturador_obj = self.openerp.pool.get(
             'giscedata.facturacio.facturador'
         )
         self.openerp.install_module(
-            'giscedata_tarifas_pagos_capacidad_20170101'
+            'giscedata_tarifas_pagos_capacidad_20220101'
         )
         self.openerp.install_module(
-            'giscedata_tarifas_peajes_20170101'
+            'giscedata_tarifas_peajes_20220101'
         )
+        self.openerp.install_module(
+            'giscedata_tarifas_cargos_20220101'
+        )
+
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
             uid = txn.user
+
+            token = tools.config['esios_token']
 
             contract_obj = self.openerp.pool.get('giscedata.polissa')
             imd_obj = self.openerp.pool.get('ir.model.data')
             pricelist_obj = self.openerp.pool.get('product.pricelist')
 
-            # gets contract 0001
+            # gets contract 018 (with tariff 2.0TD)
             contract_id_index = imd_obj.get_object_reference(
-                cursor, uid, 'giscedata_polissa', 'polissa_0001'
-            )[1]
-
-            contract_id_atr = imd_obj.get_object_reference(
-                cursor, uid, 'giscedata_polissa', 'polissa_0002'
+                cursor, uid, 'giscedata_polissa', 'polissa_tarifa_018'
             )[1]
 
             pricelist_id = imd_obj.get_object_reference(
@@ -459,64 +458,203 @@ class IndexadaSOMTest(testing.OOTestCase):
             )[1]
 
             # change formula to 'Pass-Through Ebroenergia'
-            pricelist_obj.write(cursor, uid, pricelist_id, {'indexed_formula': u'Indexada Península'})
+            pricelist_obj.write(cursor, uid, pricelist_id, {'indexed_formula': u'Indexada Balears'})
+
+            contract_obj.write(cursor, uid, [contract_id_index], {'mode_facturacio': 'index'})
 
             contract_obj.send_signal(
                 cursor, uid, [contract_id_index], ['validar', 'contracte']
             )
             self.crear_modcon(
-                cursor, uid, contract_id_index, '2017-01-01', '2017-12-31'
+                cursor, uid, contract_id_index, '2022-01-01', '2022-12-31'
             )
 
             context = {'llista_preu': pricelist_id}
             versions = facturador_obj.versions_de_preus(
-                cursor, uid, contract_id_index, '2017-01-01', '2017-01-31',
+                cursor, uid, contract_id_index, '2022-01-01', '2022-12-31',
                 context
             )
 
             curve_data = self.get_curve()
-            curve = Curve(datetime(2017, 1, 1))
+            curve = Curve(datetime(2022, 1, 1))
             curve.load(curve_data)
 
             consums = {
-                'activa': {'2017-01-01': curve_data},
+                'activa': {'2022-01-01': curve_data},
                 'reactiva': {'P1': 2}
             }
-            tarifa = Tarifa20APoolSOM(
+            tarifa = Tarifa20TDPoolSOM(
                 consums, {},
-                '2017-01-01', '2017-01-31',
+                '2022-01-01', '2022-01-31',
                 facturacio=1, facturacio_potencia='icp',
-                data_inici_periode='2017-01-01',
-                data_final_periode='2017-01-31',
-                potencies_contractades={'P1': 4.6},
+                data_inici_periode='2022-01-01',
+                data_final_periode='2022-01-31',
+                potencies_contractades={'P1': 4.6, 'P2': 4.6},
                 versions=versions,
                 holidays=HOLIDAYS,
                 esios_token=token,
-                audit=['pmd', 'curve'],
-                indexed_formula=u'Indexada Balears'
+                audit=['pmd', 'curve', 'ph', 'phf'],
+                indexed_formula=u'Indexada Balears',
+                geom_zone='2'
             )
 
-            getattr(tarifa, tarifa.phf_function)(
-                curve, date(2017, 1, 1)
+            component = tarifa.phf_calc_balears(
+                curve, date(2022, 1, 1)
             )
 
             # test component
             tarifa.factura_energia()
-            assert tarifa.code == '2.0A'
+            assert tarifa.code == '2.0TD'
 
             # CURVE
             curve_audit = tarifa.get_audit_data('curve')
             tarifa.dump_audit_data('curve', '/tmp/curve_data.csv')
             # test
             expect(curve_audit[0]).to(
-                equal(("2017-01-01 01", 0.001, '', ''))
+                equal(("2022-01-01 01", 0.001, '', ''))
             )
             expect(curve_audit[-1]).to(
-                equal(("2017-01-31 24", 0.03123, '', ''))
+                equal(("2022-01-31 24", 0.03123, '', ''))
             )
             with open('/tmp/curve_data.csv', 'r') as curvefile:
                 first_line = curvefile.readline()
-            expect(first_line).to(equal('2017-01-01 01;0.001;;\r\n'))
+            expect(first_line).to(equal('2022-01-01 01;0.001;;\r\n'))
 
             if os.path.exists('/tmp/curve_data.csv'):
                 os.remove('/tmp/curve_data.csv')
+
+            # PH (coste horario)
+            tarifa.dump_audit_data('ph', '/tmp/ph_data.csv')
+            with open('/tmp/ph_data.csv', 'r') as curvefile:
+                first_line = curvefile.readline()
+            expect(first_line).to(equal('2022-01-01 01;1.187037;;\r\n'))
+
+            if os.path.exists('/tmp/ph_data.csv'):
+                os.remove('/tmp/ph_data.csv')
+
+            # PHF (precio horario)
+            tarifa.dump_audit_data('phf', '/tmp/phf_data.csv')
+            with open('/tmp/phf_data.csv', 'r') as curvefile:
+                first_line = curvefile.readline()
+            expect(first_line).to(equal('2022-01-01 01;0.001187;;\r\n'))
+
+            if os.path.exists('/tmp/phf_data.csv'):
+                os.remove('/tmp/phf_data.csv')
+
+    def test_phf_canaries(self):
+        facturador_obj = self.openerp.pool.get(
+            'giscedata.facturacio.facturador'
+        )
+        self.openerp.install_module(
+            'giscedata_tarifas_pagos_capacidad_20220101'
+        )
+        self.openerp.install_module(
+            'giscedata_tarifas_peajes_20220101'
+        )
+        self.openerp.install_module(
+            'giscedata_tarifas_cargos_20220101'
+        )
+
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+
+            token = tools.config['esios_token']
+
+            contract_obj = self.openerp.pool.get('giscedata.polissa')
+            imd_obj = self.openerp.pool.get('ir.model.data')
+            pricelist_obj = self.openerp.pool.get('product.pricelist')
+
+            # gets contract 018 (with tariff 2.0TD)
+            contract_id_index = imd_obj.get_object_reference(
+                cursor, uid, 'giscedata_polissa', 'polissa_tarifa_018'
+            )[1]
+
+            pricelist_id = imd_obj.get_object_reference(
+                cursor, uid, 'giscedata_facturacio',
+                'pricelist_tarifas_electricidad'
+            )[1]
+
+            # change formula to 'Pass-Through Ebroenergia'
+            pricelist_obj.write(cursor, uid, pricelist_id, {'indexed_formula': u'Indexada Balears'})
+
+            contract_obj.write(cursor, uid, [contract_id_index], {'mode_facturacio': 'index'})
+
+            contract_obj.send_signal(
+                cursor, uid, [contract_id_index], ['validar', 'contracte']
+            )
+            self.crear_modcon(
+                cursor, uid, contract_id_index, '2022-01-01', '2022-12-31'
+            )
+
+            context = {'llista_preu': pricelist_id}
+            versions = facturador_obj.versions_de_preus(
+                cursor, uid, contract_id_index, '2022-01-01', '2022-12-31',
+                context
+            )
+
+            curve_data = self.get_curve()
+            curve = Curve(datetime(2022, 1, 1))
+            curve.load(curve_data)
+
+            consums = {
+                'activa': {'2022-01-01': curve_data},
+                'reactiva': {'P1': 2}
+            }
+            tarifa = Tarifa20TDPoolSOM(
+                consums, {},
+                '2022-01-01', '2022-01-31',
+                facturacio=1, facturacio_potencia='icp',
+                data_inici_periode='2022-01-01',
+                data_final_periode='2022-01-31',
+                potencies_contractades={'P1': 4.6, 'P2': 4.6},
+                versions=versions,
+                holidays=HOLIDAYS,
+                esios_token=token,
+                audit=['pmd', 'curve', 'ph', 'phf'],
+                indexed_formula=u'Indexada Canàries',
+                geom_zone='3'
+            )
+
+            component = tarifa.phf_calc_canaries(
+                curve, date(2022, 1, 1)
+            )
+
+            # test component
+            tarifa.factura_energia()
+            assert tarifa.code == '2.0TD'
+
+            # CURVE
+            curve_audit = tarifa.get_audit_data('curve')
+            tarifa.dump_audit_data('curve', '/tmp/curve_data.csv')
+            # test
+            expect(curve_audit[0]).to(
+                equal(("2022-01-01 01", 0.001, '', ''))
+            )
+            expect(curve_audit[-1]).to(
+                equal(("2022-01-31 24", 0.03123, '', ''))
+            )
+            with open('/tmp/curve_data.csv', 'r') as curvefile:
+                first_line = curvefile.readline()
+            expect(first_line).to(equal('2022-01-01 01;0.001;;\r\n'))
+
+            if os.path.exists('/tmp/curve_data.csv'):
+                os.remove('/tmp/curve_data.csv')
+
+            # PH (coste horario)
+            tarifa.dump_audit_data('ph', '/tmp/ph_data.csv')
+            with open('/tmp/ph_data.csv', 'r') as curvefile:
+                first_line = curvefile.readline()
+            expect(first_line).to(equal('2022-01-01 01;1.176631;;\r\n'))
+
+            if os.path.exists('/tmp/ph_data.csv'):
+                os.remove('/tmp/ph_data.csv')
+
+            # PHF (precio horario)
+            tarifa.dump_audit_data('phf', '/tmp/phf_data.csv')
+            with open('/tmp/phf_data.csv', 'r') as curvefile:
+                first_line = curvefile.readline()
+            expect(first_line).to(equal('2022-01-01 01;0.001177;;\r\n'))
+
+            if os.path.exists('/tmp/phf_data.csv'):
+                os.remove('/tmp/phf_data.csv')


### PR DESCRIPTION
## Objectiu

- Implementar dues noves fòrmulas de preu indexat destinades pels clients extrapeninsulars residents a `Balears` i `Canàries`.

#### PHF BALEARS

 `PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K + D] + PA + CA`

on:
* **IMU**: Impost Municipal [%]
* **SPHDEM**:  Precio Medio de Demanda en los sistemas no peninsulares [€/MWh]
* **PC_REE**: Pagos por capacidad según REE [€/kWh]
* **SI**: Precio Servicio Interrumpibilidad [€/MWh]
* **POS**: Preu retribució a l'Operador del Sistema (REE) [€/MWh]
* **Perdidas**: Perdidas por tarifa [%]
* **FNEE**: Pagos al fondo de eficiencia según consumo computado [€/MWh]
* **K**: Coeficiente de comercializadora [€/kWh]
* **D**: Coeficiente de desvíos [€/kWh]
* **PA**: Peajes de acceso según BOE [€/kWh]
* **CA**: Cargos según BOE [€/kWh]

#### PHF CANARIES

 `PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K + D] + PA + CA`

on:
* **IMU**: Impost Municipal [%]
* **SPHDEM**:  Precio Medio de Demanda en los sistemas no peninsulares [€/MWh]
* **PC_REE**: Pagos por capacidad según REE [€/kWh]
* **SI**: Precio Servicio Interrumpibilidad [€/MWh]
* **POS**: Preu retribució a l'Operador del Sistema (REE) [€/MWh]
* **Perdidas**: Perdidas por tarifa [%]
* **FNEE**: Pagos al fondo de eficiencia según consumo computado [€/MWh]
* **K**: Coeficiente de comercializadora [€/kWh]
* **D**: Coeficiente de desvíos [€/kWh]
* **PA**: Peajes de acceso según BOE [€/kWh]
* **CA**: Cargos según BOE [€/kWh]

## Afectacions
- [ ] Codi. Reiniciar serveis:
    - `erp`
    - `backgrounder`

## Relacionat

- Requereix https://github.com/gisce/libFacturacioATR/pull/210
