### PR TITLE
Adaptació de les fórmules al RDL 10/2022

### DIFF
--- a/tarifes.py
+++ b/tarifes.py
@@ -123,7 +123,19 @@ class TarifaPoolSOM(TarifaPool):
             'C2_%(fname)s_%(postfix)s' % locals(), esios_token
         )
 
+        # MAJ RDL 10/2022
+        maj_activated = self.conf.get('maj_activated', 0)
+
         A = (((prmncur - pc3_ree) * 0.001) + pc3_boe + (omie * 0.001))
+
+        # Use AJOM if invoice includes june'22 or later days and variable is activated
+        if maj_activated and (
+                (start_date.year >= 2022 and start_date.month >= 6) or
+                (start_date.year == 2023 and start_date.month < 6)
+        ):
+            ajom = self.get_coeficient_from_dict(start_date, 'ajom')
+            A += ajom * 0.001
+
         B = (1 + (perdues * 0.01))
         C = A * B
         D = (k + desvios) + (fe * 0.001)
@@ -197,7 +209,24 @@ class TarifaPoolSOM(TarifaPool):
         coste_medio_desvios.load(grcosdnc.indicators[GRCOSDNC_MAGNS[8]])
         sobrecostes_ree = coste_total - coste_medio_desvios
 
+        # MAJ RDL 10/2022
+        maj_activated = self.conf.get('maj_activated', 0)
+
         A = ((prmdiari + sobrecostes_ree + si) * 0.001) + pc3_boe + (omie * 0.001) + h
+
+        # Use AJOM if invoice includes june'22 or later days and variable is activated
+        if maj_activated and (
+                (start_date.year >= 2022 and start_date.month >= 6) or
+                (start_date.year == 2023 and start_date.month < 6)
+        ):
+            ajom = self.get_coeficient_from_dict(start_date, 'ajom')
+
+            grcosdnc = Grcosdnc('C2_grcosdnc_%(postfix)s' % locals(), esios_token)  # [€/MWh]
+            maj3 = Component(data=grcosdnc.start_date, version=grcosdnc.version)
+            maj3.load(grcosdnc.indicators[GRCOSDNC_MAGNS_2022[12]])
+
+            A += (ajom + maj3) * 0.001
+
         B = (1 + (perdues * 0.01))
         C = A * B
         D = (fe * 0.001) + k + d


### PR DESCRIPTION
## Objectius

- Afegir els components `AJOM` i `MAJ3` a les fórmules quan es cumpleixin totes les condicions següents:
    - Quan el periode facturat contingui dies entre el 15 de juny de 2022 i el 31 de maig.
    - Quan la variable `maj_activated` arribi activada al facturador.
    - Quan la fórmula apliqui sobre contractes no extra-peninsulars.

- El component `MAJ3` s'aplicarà només si la fórmula no fa servir el component `prmncur`.
