### PR TITLE
✨ Restar el Sphauto al Sphdem a les fòrmules de Balears i Canaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,15 @@ Where:
 * **pmd**: prmdiari
 * **perdues**: perdxxxxx
 
-## PHF BALEARES formula
+## PHF CANARIAS formula
 
- `PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K + D] + PA + CA`
+ `PHF = (1 + IMU) * [(SPHDEM - SPHAUTO + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K + D] + PA + CA`
 
 Where:
 
 * **IMU**: Impost Municipal [%]
 * **SPHDEM**:  Precio Medio de Demanda en los sistemas no peninsulares [€/MWh]
+* **SPHAUTO**:  TODO: Descripción del Sphauto
 * **PC_REE**: Pagos por capacidad según REE [€/kWh]
 * **SI**: Precio Servicio Interrumpibilidad [€/MWh]
 * **POS**: Preu Operació Sistema (REE) [€/MWh]
@@ -137,12 +138,13 @@ Where:
 
 ## PHF BALEARES formula
 
- `PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K + D] + PA + CA`
+ `PHF = (1 + IMU) * [(SPHDEM - SPHAUTO + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K + D] + PA + CA`
 
 Where:
 
 * **IMU**: Impost Municipal [%]
 * **SPHDEM**:  Precio Medio de Demanda en los sistemas no peninsulares [€/MWh]
+* **SPHAUTO**:  TODO: Descripción del Sphauto
 * **PC_REE**: Pagos por capacidad según REE [€/kWh]
 * **SI**: Precio Servicio Interrumpibilidad [€/MWh]
 * **POS**: Preu Operació Sistema [€/MWh]

--- a/tarifes.py
+++ b/tarifes.py
@@ -294,7 +294,7 @@ class TarifaPoolSOM(TarifaPool):
     def phf_calc_balears(self, curve, start_date):
         """
         Calcs component PHF as:
-        PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K] + PA + CA
+        PHF = (1 + IMU) * [(SPHDEM - SPHAUTO + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K] + PA + CA
         :param curve: Component curve
         :param start_date: component start date
         :return: returns a component
@@ -315,6 +315,10 @@ class TarifaPoolSOM(TarifaPool):
         filename = 'SphdemDD_{}'.format(SUBSYSTEMS_SPHDEM[self.geom_zone])
         classname = globals()[filename]
         sphdem = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
+        # Precio compensacion
+        filename = 'Sphauto_{}'.format(SUBSYSTEMS_SPHDEM[self.geom_zone])
+        classname = globals()[filename]
+        sphauto = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
         # Pagos por capacidad
         filename = 'Sprpcap{}_{}'.format(self.code.replace('.', ''), SUBSYSTEMS_SPHDEM[self.geom_zone])
         classname = globals()[filename]
@@ -340,7 +344,7 @@ class TarifaPoolSOM(TarifaPool):
         # peajes y cargos
         pa = self.get_peaje_component(start_date, holidays)  # [€/kWh]
 
-        A = ((sphdem + pc3_ree + si + ree) * 0.001)
+        A = ((sphdem - sphauto + pc3_ree + si + ree) * 0.001)
         B = (1 + (perdues * 0.01))
         C = A * B
         D = (fe * 0.001) + k + d
@@ -365,7 +369,7 @@ class TarifaPoolSOM(TarifaPool):
     def phf_calc_canaries(self, curve, start_date):
         """
         Calcs component PHF as:
-        PHF = (1 + IMU) * [(SPHDEM + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K] + PA + CA
+        PHF = (1 + IMU) * [(SPHDEM - SPHAUTO + PC_REE + SI + POS) * (1 + Perdidas) + FNEE + K] + PA + CA
         :param curve: Component curve
         :param start_date: component start date
         :return: returns a component
@@ -386,6 +390,10 @@ class TarifaPoolSOM(TarifaPool):
         filename = 'SphdemDD_{}'.format(SUBSYSTEMS_SPHDEM[self.geom_zone])
         classname = globals()[filename]
         sphdem = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
+        # Precio compensacion
+        filename = 'Sphauto_{}'.format(SUBSYSTEMS_SPHDEM[self.geom_zone])
+        classname = globals()[filename]
+        sphauto = classname('C2_%(filename)s_%(postfix)s' % locals(), esios_token)  # [€/MWh]
         # Pagos por capacidad
         filename = 'Sprpcap{}_{}'.format(self.code.replace('.', ''), SUBSYSTEMS_SPHDEM[self.geom_zone])
         classname = globals()[filename]
@@ -411,7 +419,7 @@ class TarifaPoolSOM(TarifaPool):
         # peajes y cargos
         pa = self.get_peaje_component(start_date, holidays)  # [€/kWh]
 
-        A = ((sphdem + pc3_ree + si + ree) * 0.001)
+        A = ((sphdem - sphauto + pc3_ree + si + ree) * 0.001)
         B = (1 + (perdues * 0.01))
         C = A * B
         D = (fe * 0.001) + k + d


### PR DESCRIPTION
## Descripció

✨ Restar el Sphauto al Sphdem a les fòrmules de Balears i Canaries

## Targeta on es demana

https://secure.helpscout.net/conversation/2537765133/16743148/
Actualment el preu compensació excedents a illes és idem al preu de compra (SphDem) Cal modificar aquesta variable per tal de que l preu de compensació sigui = SphDem -SphAuto (BALEARS i CANARIAS) Aquest canvi afectarà als excedents compensats a partir de l'aplicació, i no serà necessari refacturar les emeses anteriorment
