### PR TITLE
Fix available audit coefs gen

### DIFF
--- a/tarifes.py
+++ b/tarifes.py
@@ -93,7 +93,7 @@ class TarifaPoolSOM(TarifaPool):
             'phf_gen': 'component',
         }
         """
-        res = super(TarifaPoolSOM, self).get_available_audit_coefs()
+        res = super(TarifaPoolSOM, self).get_available_audit_coefs_gen()
         res['pvpc_gen'] = 'prmdiari'
         res['sphdem'] = 'sphdem'
         res['sphauto'] = 'sphauto'


### PR DESCRIPTION
## Description

Corregir la obtenció dels components de generació base a auditar

## Changes

- En la fórmula indexada de generació, en comptes d'agafar els de consum, s'agafen els de generació:

  - 'pvpc_gen': 'pvpc',
  - 'curve_gen': 'B',
  - 'phf_gen': 'component',

